### PR TITLE
Поправлены таймауты при подключении к IMAP

### DIFF
--- a/internal/email/connect.go
+++ b/internal/email/connect.go
@@ -1,31 +1,41 @@
 package email
 
 import (
+	"crypto/tls"
 	"fmt"
 	"github.com/emersion/go-imap/client"
 	"github.com/st-kuptsov/mail2tg/config"
 	"go.uber.org/zap"
+	"net"
 	"time"
 )
 
-// ConnectToIMAP подключается к IMAP-серверу по TLS, выполняет авторизацию и возвращает клиент.
-// Логирует ключевые шаги и обновляет метрику доступности UpGauge.
+// ConnectToIMAP подключается к IMAP-серверу по TLS с таймаутами и возвращает клиента
 func ConnectToIMAP(cfg *config.Config, logger *zap.SugaredLogger) (*client.Client, error) {
 	addr := fmt.Sprintf("%s:%d", cfg.IMAP.Host, cfg.IMAP.Port)
 	logger.Infow("connecting to IMAP server", "address", addr)
 
-	// Подключаемся к серверу
-	c, err := client.DialTLS(addr, nil)
+	// создаем Dialer с таймаутом
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second, // время на установку соединения
+	}
+
+	// создаем TLS-коннект с таймаутом
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr, &tls.Config{})
 	if err != nil {
 		logger.Errorw("failed to connect to IMAP server", "error", err)
 		return nil, fmt.Errorf("failed to connect to IMAP: %w", err)
 	}
 
-	// Устанавливаем таймауты
-	c.Timeout = 30 * time.Second
+	// создаем IMAP-клиент поверх уже установленного соединения
+	c, err := client.New(conn)
+	if err != nil {
+		logger.Errorw("failed to create IMAP client", "error", err)
+		return nil, fmt.Errorf("failed to create IMAP client: %w", err)
+	}
+
 	logger.Info("IMAP connection established")
 
-	// Выполняем логин
 	if err := c.Login(cfg.IMAP.Username, cfg.IMAP.Password); err != nil {
 		logger.Errorw("IMAP login failed", "error", err)
 		return nil, fmt.Errorf("IMAP login failed: %w", err)


### PR DESCRIPTION
- Добавлена установка таймаутов при подключении к IMAP через tls.DialWithDialer.
- Теперь соединение обрывается, если сервер не отвечает дольше 10 секунд.
- Устранён риск "зависших" подключений при сетевых проблемах.
- Логирование улучшено: ошибки подключения и логина отображаются отдельно.